### PR TITLE
RocksDB: Link against libdl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ t_pebbles.o: t_pebbles.cc
 	$(CXX) -c $(CFLAGS) -I../pebblesdb/include $^
 
 $(BINDIR)/t_rocksdb: dbb.o t_rocksdb.o
-	$(CXX) -o $@ $^ ../rocksdb/librocksdb.a -lsnappy -llz4 -lz -lbz2 -lzstd
+	$(CXX) -o $@ $^ ../rocksdb/librocksdb.a -ldl -lsnappy -llz4 -lz -lbz2 -lzstd
 t_rocksdb.o: t_rocksdb.cc
 	$(CXX) -std=c++11 -c $(CFLAGS) -I../rocksdb/include $^
 


### PR DESCRIPTION
Fix linking errors for building t_rocksdb.