### PR TITLE
Update Makefile and t_leaves.cc for improved compilation and function…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ $(BINDIR)/t_mdbx: dbb.o t_mdbx.o
 	$(CC) -o $@ $^ -Wl,-Bstatic -lmdbx -Wl,-Bdynamic -lsnappy -lm
 
 $(BINDIR)/t_leaves: dbb.o t_leaves.o
-	$(CXX) -o $@ $^
+	$(CXX)  -o $@ $^
 t_leaves.o: t_leaves.cc
-	$(CXX) -c $(CFLAGS) -std=c++20 -I../leaves/include $^
+	$(CXX) -c $(CFLAGS) -std=c++20 -mpopcnt -mbmi -mlzcnt -mavx2 -I../leaves/include $^
 
 $(BINDIR)/t_leveldb: dbb.o t_leveldb.o
 	$(CXX) -o $@ $^ ../leveldb/out-static/libleveldb.a -lsnappy

--- a/t_leaves.cc
+++ b/t_leaves.cc
@@ -66,6 +66,7 @@ static void db_read(DBB_local *dl) {
 		size_t found = 0;
 		char key[100];
 		do {
+			cursor.update();
 			const uint64_t k = DBB_random(dl->dl_rndctx) % FLAGS_num;
 			snprintf(key, sizeof(key), "%016lx", k);
 			read++;


### PR DESCRIPTION

- Correct handling of read cursor in the benchmark
- Added optimization flags in Makefile for t_leaves.o compilation. (needed for efficient bit calculations)
